### PR TITLE
logging: remove video-specific youtube errors

### DIFF
--- a/video2dataset/worker.py
+++ b/video2dataset/worker.py
@@ -139,7 +139,7 @@ class Worker:
 
                     if error_message is not None:
                         if "[youtube]" in error_message: # video-specific error, remove videoID
-                            error_message = "ERROR: [youtube]" + error_message[len("ERROR: [youtube] FCMEClg-doU"):]
+                            error_message = "ERROR: [youtube]:" + error_message.split(":")[-1]
                         failed_to_download += 1
                         status = "failed_to_download"
                         status_dict.increment(error_message)

--- a/video2dataset/worker.py
+++ b/video2dataset/worker.py
@@ -138,6 +138,8 @@ class Worker:
                     }
 
                     if error_message is not None:
+                        if "youtube" in error_message: # video-specific error, remove videoID
+                            error_message = "ERROR: [youtube]" + error_message[len("ERROR: [youtube] FCMEClg-doU"):]
                         failed_to_download += 1
                         status = "failed_to_download"
                         status_dict.increment(error_message)

--- a/video2dataset/worker.py
+++ b/video2dataset/worker.py
@@ -138,7 +138,7 @@ class Worker:
                     }
 
                     if error_message is not None:
-                        if "[youtube]" in error_message: # video-specific error, remove videoID
+                        if "[youtube]" in error_message:  # video-specific error, remove videoID
                             error_message = "ERROR: [youtube]:" + error_message.split(":")[-1]
                         failed_to_download += 1
                         status = "failed_to_download"

--- a/video2dataset/worker.py
+++ b/video2dataset/worker.py
@@ -138,7 +138,7 @@ class Worker:
                     }
 
                     if error_message is not None:
-                        if "youtube" in error_message: # video-specific error, remove videoID
+                        if "[youtube]" in error_message: # video-specific error, remove videoID
                             error_message = "ERROR: [youtube]" + error_message[len("ERROR: [youtube] FCMEClg-doU"):]
                         failed_to_download += 1
                         status = "failed_to_download"


### PR DESCRIPTION
Example video-specific error messages:

- ERROR: [youtube] KqM_GGR5lig: This video has been removed by the uploader
- ERROR: [youtube] Cblh2cCXp44: This video is private. If the owner of this video has granted you access, please sign in.
- ERROR: [youtube] 5M-oyVRI4fA: The uploader has not made this video available in your country

All have the same format of: ERROR: [youtube] video_id: message