### PR TITLE
requirements: add webvtt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ yt_dlp
 pyarrow
 fsspec
 webdataset
+webvtt-py
 wandb
 pandas
 tqdm

--- a/video2dataset/data_reader.py
+++ b/video2dataset/data_reader.py
@@ -4,11 +4,7 @@ import uuid
 import requests
 import yt_dlp
 import io
-
-try:
-    import webvtt  # pip install webvtt-py
-except ImportError as err:
-    print(err)
+import webvtt
 
 
 def sub_to_dict(sub, dedupe=True, single=False) -> list:


### PR DESCRIPTION
I suggest just adding it, most datasets are clip-subtitle dataset + I'm not sure it's worth considering if we absolutely need everything f.e. if someone just wants the videos without subsampling we don't need ffmpeg-python.

Open to keeping it this way though and reconsidering a few of the packages we already have in requirements 