### PR TITLE
Add support for subtitles from multiple languages

### DIFF
--- a/API.md
+++ b/API.md
@@ -141,7 +141,7 @@ reading:
     yt_args:
         download_size: 360
         yt_metadata_args:
-            writesubtitles:  True
+            writesubtitles: 'all'
             subtitleslangs: ['en']
             writeautomaticsub: True
             get_info: True

--- a/dataset_examples/HDVILA.md
+++ b/dataset_examples/HDVILA.md
@@ -68,7 +68,7 @@ reading:
         download_size: 360
         download_audio_rate: 44100
         yt_metadata_args:
-            writesubtitles:  True
+            writesubtitles: 'all'
             subtitleslangs: ['en']
             writeautomaticsub: True
             get_info: True

--- a/dataset_examples/VideoCC.md
+++ b/dataset_examples/VideoCC.md
@@ -44,7 +44,7 @@ reading:
         download_size: 360
         download_audio_rate: 44100
         yt_metadata_args:
-            writesubtitles:  True
+            writesubtitles:  'all'
             subtitleslangs: ['en']
             writeautomaticsub: True
             get_info: True

--- a/examples/default_slurm.yaml
+++ b/examples/default_slurm.yaml
@@ -5,7 +5,7 @@ reading:
         download_size: 360
         download_audio_rate: 44100
         yt_metadata_args:
-            writesubtitles:  True
+            writesubtitles: 'all'
             subtitleslangs: ['en']
             writeautomaticsub: True
             get_info: True

--- a/examples/yt_metadata.md
+++ b/examples/yt_metadata.md
@@ -9,7 +9,7 @@ yt_args:
     download_size: 360
     download_audio_rate: 44100
     yt_metadata_args:
-        writesubtitles:  True
+        writesubtitles: 'all'
         subtitleslangs: ['en']
         writeautomaticsub: True
         get_info: True

--- a/examples/yt_metadata.md
+++ b/examples/yt_metadata.md
@@ -123,3 +123,118 @@ For every sample the metadata will be present in the json file as such:
 ```
 
 And since we specified that captions_are_subtitles the txt file will have the subtitle for that given clip inside of it. For this particular example it would be: "analytics to assess performance based on"
+
+#### Multilingual Subtitles
+To control the language/s of the subtitles from your videos, you can prvoide either `'first'` or `'all'` for `writesubtitles` (any value that evalutes to True will work also work as `'all'`).
+
+`first`: This will extract subtitles for the first language that is in `subtitleslangs` for which there exists subtitles. \
+`all`: Attempt to extract subtitles for every language in `subtitleslangs`.
+
+Below are some example outputs with `subtitleslangs: ['en', 'es', 'fr']`.
+
+Using `writesubtitles: 'first'`:
+```json
+{
+    "url": "https://www.youtube.com/watch?v=CvHAfXKIvgw",
+    ...
+    "yt_meta_dict": {
+        ...
+        "subtitles": {
+            "en": [
+                {
+                    "start": "00:00:02.100",
+                    "end": "00:00:03.360",
+                    "lines": [
+                        "Good morning Lisa"
+                    ]
+                },
+                ...
+            ]
+        }
+    },
+    "clips": [
+        [
+            2.1,
+            3.36
+        ]
+    ],
+    "clip_subtitles": [
+        {
+            "start": "00:00:02.100",
+            "end": "00:00:03.360",
+            "lines": {
+                "en": [
+                    "Good morning Lisa"
+                ]
+            }
+        }
+    ]
+}
+```
+
+
+Using `writesubtitles: 'all'`:
+```json
+{
+    "url": "https://www.youtube.com/watch?v=CvHAfXKIvgw",
+    ...
+    "yt_meta_dict": {
+        ...
+        "subtitles": {
+            "en": [
+                {
+                    "start": "00:00:02.100",
+                    "end": "00:00:03.360",
+                    "lines": [
+                        "Good morning Lisa"
+                    ]
+                },
+                ...
+            ],
+            "es": [
+                {
+                    "start": "00:00:02.100",
+                    "end": "00:00:03.360",
+                    "lines": [
+                        "Buenos d\u00edas Lisa"
+                    ]
+                },
+                ...
+            ],
+            "fr": [
+                {
+                    "start": "00:00:02.100",
+                    "end": "00:00:03.360",
+                    "lines": [
+                        "Bonjour Lisa"
+                    ]
+                },
+                ...
+            ]
+        }
+    },
+    "clips": [
+        [
+            2.1,
+            3.36
+        ]
+    ],
+    "clip_subtitles": [
+        {
+            "start": "00:00:02.100",
+            "end": "00:00:03.360",
+            "lines": {
+                "en": [
+                    "Good morning Lisa"
+                ],
+                "es": [
+                    "Buenos d\u00edas Lisa"
+                ],
+                "fr": [
+                    "Bonjour Lisa"
+                ]
+            }
+        }
+    ]
+}
+```

--- a/tests/test_yt_meta.py
+++ b/tests/test_yt_meta.py
@@ -51,8 +51,9 @@ def test_subtitles(input_file):
         yt_meta_dict = get_yt_meta(url, yt_metadata_args)
 
         assert type(yt_meta_dict) == dict
-        assert type(yt_meta_dict["subtitles"]) == list
-        assert type(yt_meta_dict["subtitles"][0]) == dict
+        assert type(yt_meta_dict["subtitles"]) == dict
+        assert type(yt_meta_dict["subtitles"]["en"]) == list
+        assert type(yt_meta_dict["subtitles"]["en"][0]) == dict
 
 
 @pytest.mark.parametrize("input_file", ["test_yt.csv"])

--- a/video2dataset/configs/default.yaml
+++ b/video2dataset/configs/default.yaml
@@ -5,7 +5,7 @@ reading:
         download_size: 360
         download_audio_rate: 44100
         yt_metadata_args:
-            writesubtitles:  True
+            writesubtitles:  'all'
             subtitleslangs: ['en']
             writeautomaticsub: True
             get_info: True

--- a/video2dataset/configs/downsample_ml.yaml
+++ b/video2dataset/configs/downsample_ml.yaml
@@ -28,7 +28,7 @@ reading:
         download_size: 360
         download_audio_rate: 44100
         yt_metadata_args:
-            writesubtitles:  True
+            writesubtitles: 'all'
             subtitleslangs: ['en']
             writeautomaticsub: True
             get_info: True

--- a/video2dataset/data_reader.py
+++ b/video2dataset/data_reader.py
@@ -102,7 +102,7 @@ def get_yt_meta(url, yt_metadata_args: dict) -> dict:
             info_dict.pop("automatic_captions")
         else:
             info_dict = None
-        
+
         yt_meta_dict = {"info": info_dict, "subtitles": full_sub_dict}
 
         return yt_meta_dict

--- a/video2dataset/data_reader.py
+++ b/video2dataset/data_reader.py
@@ -84,10 +84,8 @@ def get_yt_meta(url, yt_metadata_args: dict) -> dict:
         if write_subs:
             full_sub_dict = {}
             for lang in yt_metadata_args["subtitleslangs"]:
-                print(lang)
                 if lang not in info_dict["requested_subtitles"]:
                     continue
-                print("1")
                 sub_url = info_dict["requested_subtitles"][lang]["url"]
                 res = requests.get(sub_url, timeout=10)
                 sub = io.TextIOWrapper(io.BytesIO(res.content)).read()
@@ -105,7 +103,6 @@ def get_yt_meta(url, yt_metadata_args: dict) -> dict:
         else:
             info_dict = None
         
-        print(full_sub_dict)
         yt_meta_dict = {"info": info_dict, "subtitles": full_sub_dict}
 
         return yt_meta_dict

--- a/video2dataset/data_reader.py
+++ b/video2dataset/data_reader.py
@@ -56,22 +56,19 @@ def get_yt_meta(url, yt_metadata_args: dict) -> dict:
     """Return yt meta dict with meta data and/or subtitles
     yt_metadata_args is a dict of follwing format:
     yt_metadata_args = {
-        'writesubtitles': True,
-        'writealllangs': True,
+        'writesubtitles': 'first',
         'subtitleslangs': ['en'],
         'writeautomaticsub': True,
         'get_info': True
     }
 
-    writesubtitles:    Whether to write subtitles
-    writealllangs:     Whether to write subtitles for each provided language or just the first present
+    writesubtitles:    Whether to write subtitles for each provided language or just the first present
     writeautomaticsub: Write the automatically generated subtitles to a file
     subtitleslangs:    List of languages of the subtitles to download.
-    get_info: whether to add info (title, description, tags etc) to the output.
+    get_info:          Whether to add info (title, description, tags etc) to the output.
     """
 
     write_subs = yt_metadata_args.get("writesubtitles", None)
-    write_all_langs = yt_metadata_args.get("writealllangs", False)
 
     yt_metadata_args["skip_download"] = True
     yt_metadata_args["ignoreerrors"] = True
@@ -91,7 +88,7 @@ def get_yt_meta(url, yt_metadata_args: dict) -> dict:
                 sub = io.TextIOWrapper(io.BytesIO(res.content)).read()
                 full_sub_dict[lang] = sub_to_dict(sub)
 
-                if not write_all_langs:
+                if write_subs == "first":
                     break
 
         if yt_metadata_args["get_info"]:

--- a/video2dataset/main.py
+++ b/video2dataset/main.py
@@ -126,8 +126,7 @@ def video2dataset(
         assert clip_col is None  # no weird double-clipping
         if config["reading"]["yt_args"]["yt_metadata_args"] is None:
             config["reading"]["yt_args"]["yt_metadata_args"] = {}
-        if "writesubtitles" not in config["reading"]["yt_args"]["yt_metadata_args"]:
-            config["reading"]["yt_args"]["yt_metadata_args"]["writesubtitles"] = 'all'  # type: ignore
+        assert "writesubtitles" in config["reading"]["yt_args"]["yt_metadata_args"]
 
     if encode_formats is None:
         encode_formats = {"video": "mp4"}

--- a/video2dataset/main.py
+++ b/video2dataset/main.py
@@ -126,8 +126,8 @@ def video2dataset(
         assert clip_col is None  # no weird double-clipping
         if config["reading"]["yt_args"]["yt_metadata_args"] is None:
             config["reading"]["yt_args"]["yt_metadata_args"] = {}
-        if config["reading"]["yt_args"]["yt_metadata_args"]["writesubtitles"] is None:
-            config["reading"]["yt_args"]["yt_metadata_args"]["writesubtitles"] = "all"
+        if not config["reading"]["yt_args"]["yt_metadata_args"].get("writesubtitles", None):  # type: ignore
+            config["reading"]["yt_args"]["yt_metadata_args"]["writesubtitles"] = "all"  # type: ignore
 
     if encode_formats is None:
         encode_formats = {"video": "mp4"}

--- a/video2dataset/main.py
+++ b/video2dataset/main.py
@@ -126,7 +126,8 @@ def video2dataset(
         assert clip_col is None  # no weird double-clipping
         if config["reading"]["yt_args"]["yt_metadata_args"] is None:
             config["reading"]["yt_args"]["yt_metadata_args"] = {}
-        config["reading"]["yt_args"]["yt_metadata_args"]["writesubtitles"] = True  # type: ignore
+        if "writesubtitles" not in config["reading"]["yt_args"]["yt_metadata_args"]:
+            config["reading"]["yt_args"]["yt_metadata_args"]["writesubtitles"] = 'all'  # type: ignore
 
     if encode_formats is None:
         encode_formats = {"video": "mp4"}

--- a/video2dataset/main.py
+++ b/video2dataset/main.py
@@ -126,7 +126,8 @@ def video2dataset(
         assert clip_col is None  # no weird double-clipping
         if config["reading"]["yt_args"]["yt_metadata_args"] is None:
             config["reading"]["yt_args"]["yt_metadata_args"] = {}
-        assert "writesubtitles" in config["reading"]["yt_args"]["yt_metadata_args"]
+        if config["reading"]["yt_args"]["yt_metadata_args"]["writesubtitles"] is None:
+            config["reading"]["yt_args"]["yt_metadata_args"]["writesubtitles"] = "all"
 
     if encode_formats is None:
         encode_formats = {"video": "mp4"}

--- a/video2dataset/subsamplers/clipping_subsampler.py
+++ b/video2dataset/subsamplers/clipping_subsampler.py
@@ -216,14 +216,16 @@ class ClippingSubsampler(Subsampler):
 
                     yt_md_dict = meta_clip.get("yt_meta_dict", {})
                     if (yt_md_dict is not None) and (yt_md_dict.get("subtitles", None) is not None):
-                        clip_subtitles = []
+                        clip_subtitles = [{}] * len(clips)
                         s_c, e_c = _get_seconds(clip_span[0]), _get_seconds(clip_span[1])
-                        for line in meta_clip["yt_meta_dict"]["subtitles"]:
-                            s, e = _get_seconds(line["start"]), _get_seconds(line["end"])
-                            if max(s_c, s) < min(e_c, e):
-                                clip_subtitles.append(line)
-                            elif s > e_c:
-                                break
+                        for lang in meta_clip["yt_meta_dict"]["subtitles"].keys():
+                            clip_subtitles[idx][lang] = []
+                            for idx, line in enumerate(meta_clip["yt_meta_dict"]["subtitles"][lang]):
+                                s, e = _get_seconds(line["start"]), _get_seconds(line["end"])
+                                if max(s_c, s) < min(e_c, e):
+                                    clip_subtitles[idx][lang] = line
+                                elif s > e_c:
+                                    break
                         # full video subtitles might still be useful for context
                         meta_clip["clip_subtitles"] = clip_subtitles
 

--- a/video2dataset/subsamplers/clipping_subsampler.py
+++ b/video2dataset/subsamplers/clipping_subsampler.py
@@ -56,6 +56,27 @@ def _adjust_ranges_to_keyframes(ranges, keyframes):
     return adjusted_ranges
 
 
+def _extract_subtitles(clip_span, meta_clip):
+    clip_subtitles = []
+    s_c, e_c = _get_seconds(clip_span[0]), _get_seconds(clip_span[1])
+    for lang_id, (lang, subtitles) in enumerate(meta_clip["yt_meta_dict"]["subtitles"].items()):
+        idx = 0
+        for idx, line in enumerate(subtitles):
+            line_dict = {lang: line["lines"]}
+            s, e = _get_seconds(line["start"]), _get_seconds(line["end"])
+            if max(s_c, s) < min(e_c, e):
+                if lang_id != 0:
+                    clip_subtitles[idx]["lines"].update(line_dict)
+                    idx += 1
+                else:
+                    line["lines"] = line_dict
+                    clip_subtitles.append(line)
+            elif s > e_c:
+                break
+
+    return clip_subtitles
+             
+
 class ClippingSubsampler(Subsampler):
     """
     Cuts videos up into segments according to the 'clips' metadata
@@ -216,31 +237,15 @@ class ClippingSubsampler(Subsampler):
 
                     yt_md_dict = meta_clip.get("yt_meta_dict", {})
                     if (yt_md_dict is not None) and (yt_md_dict.get("subtitles", None) is not None):
-                        clip_subtitles = []
-                        s_c, e_c = _get_seconds(clip_span[0]), _get_seconds(clip_span[1])
-                        for lang_id, (lang, subtitles) in enumerate(meta_clip["yt_meta_dict"]["subtitles"].items()):
-                            idx = 0
-                            for idx, line in enumerate(subtitles):
-                                line_dict = {lang: line["lines"]}
-                                s, e = _get_seconds(line["start"]), _get_seconds(line["end"])
-                                if max(s_c, s) < min(e_c, e):
-                                    if lang_id != 0:
-                                        clip_subtitles[idx]["lines"].update(line_dict)
-                                        idx += 1
-                                    else:
-                                        line["lines"] = line_dict
-                                        clip_subtitles.append(line)
-                                elif s > e_c:
-                                    break
                         # full video subtitles might still be useful for context
-                        meta_clip["clip_subtitles"] = clip_subtitles
+                        meta_clip["clip_subtitles"] = _extract_subtitles(clip_span, meta_clip)
 
                     metadata_clips.append(meta_clip)
 
                 streams_clips[k] = stream_clips
-        
+
         # remove redundant metadata from clips after the first
-        for metadata in metadata_clips[1:]:
-            metadata["yt_meta_dict"] = {}    
+        for m_clips in metadata_clips[1:]:
+            m_clips["yt_meta_dict"] = {}
 
         return streams_clips, metadata_clips, None

--- a/video2dataset/subsamplers/clipping_subsampler.py
+++ b/video2dataset/subsamplers/clipping_subsampler.py
@@ -61,7 +61,7 @@ def _extract_subtitles(clip_span, meta_clip):
     s_c, e_c = _get_seconds(clip_span[0]), _get_seconds(clip_span[1])
     for lang_id, (lang, subtitles) in enumerate(meta_clip["yt_meta_dict"]["subtitles"].items()):
         idx = 0
-        for idx, line in enumerate(subtitles):
+        for line in subtitles:
             line_dict = {lang: line["lines"]}
             s, e = _get_seconds(line["start"]), _get_seconds(line["end"])
             if max(s_c, s) < min(e_c, e):
@@ -69,8 +69,9 @@ def _extract_subtitles(clip_span, meta_clip):
                     clip_subtitles[idx]["lines"].update(line_dict)
                     idx += 1
                 else:
-                    line["lines"] = line_dict
-                    clip_subtitles.append(line)
+                    temp_line = copy.deepcopy(line)
+                    temp_line["lines"] = line_dict
+                    clip_subtitles.append(temp_line)
             elif s > e_c:
                 break
 

--- a/video2dataset/subsamplers/clipping_subsampler.py
+++ b/video2dataset/subsamplers/clipping_subsampler.py
@@ -216,14 +216,19 @@ class ClippingSubsampler(Subsampler):
 
                     yt_md_dict = meta_clip.get("yt_meta_dict", {})
                     if (yt_md_dict is not None) and (yt_md_dict.get("subtitles", None) is not None):
-                        clip_subtitles = [{}] * len(clips)
+                        clip_subtitles = []
                         s_c, e_c = _get_seconds(clip_span[0]), _get_seconds(clip_span[1])
-                        for lang in meta_clip["yt_meta_dict"]["subtitles"].keys():
-                            clip_subtitles[idx][lang] = []
-                            for idx, line in enumerate(meta_clip["yt_meta_dict"]["subtitles"][lang]):
+                        for lang, subtitles in meta_clip["yt_meta_dict"]["subtitles"].items():
+                            for idx, line in enumerate(subtitles):
+                                line_dict = {lang: line["lines"]}
+
                                 s, e = _get_seconds(line["start"]), _get_seconds(line["end"])
                                 if max(s_c, s) < min(e_c, e):
-                                    clip_subtitles[idx][lang] = line
+                                    if idx < len(clip_subtitles):
+                                        clip_subtitles[idx]["lines"] |= line_dict
+                                    else:
+                                        line["lines"] = line_dict
+                                        clip_subtitles.apppend(line)
                                 elif s > e_c:
                                     break
                         # full video subtitles might still be useful for context

--- a/video2dataset/subsamplers/clipping_subsampler.py
+++ b/video2dataset/subsamplers/clipping_subsampler.py
@@ -57,6 +57,7 @@ def _adjust_ranges_to_keyframes(ranges, keyframes):
 
 
 def _extract_subtitles(clip_span, meta_clip):
+    """Extracts subtitles and groups them by language"""
     clip_subtitles = []
     s_c, e_c = _get_seconds(clip_span[0]), _get_seconds(clip_span[1])
     for lang_id, (lang, subtitles) in enumerate(meta_clip["yt_meta_dict"]["subtitles"].items()):
@@ -76,7 +77,7 @@ def _extract_subtitles(clip_span, meta_clip):
                 break
 
     return clip_subtitles
-             
+
 
 class ClippingSubsampler(Subsampler):
     """

--- a/video2dataset/subsamplers/clipping_subsampler.py
+++ b/video2dataset/subsamplers/clipping_subsampler.py
@@ -221,7 +221,6 @@ class ClippingSubsampler(Subsampler):
                         for lang, subtitles in meta_clip["yt_meta_dict"]["subtitles"].items():
                             for idx, line in enumerate(subtitles):
                                 line_dict = {lang: line["lines"]}
-
                                 s, e = _get_seconds(line["start"]), _get_seconds(line["end"])
                                 if max(s_c, s) < min(e_c, e):
                                     if idx < len(clip_subtitles):

--- a/video2dataset/workers/download_worker.py
+++ b/video2dataset/workers/download_worker.py
@@ -206,7 +206,8 @@ class DownloadWorker:
                             raise ValueError("failed_to_subsample")
 
                     if self.config["storage"]["captions_are_subtitles"]:  # create clips
-                        subtitles = meta["yt_meta_dict"]["subtitles"]
+                        # all langs have same start and end times
+                        subtitles = meta["yt_meta_dict"]["subtitles"][list(meta["yt_meta_dict"]["subtitles"].keys())[0]]
                         meta["clips"] = [[line_dict["start"], line_dict["end"]] for line_dict in subtitles]
                     elif self.cut_detector is not None:  # apply cut detection to get clips
                         streams, cuts, error_message = self.cut_detector(streams)

--- a/video2dataset/workers/download_worker.py
+++ b/video2dataset/workers/download_worker.py
@@ -253,7 +253,7 @@ class DownloadWorker:
 
                         text_caption = sample_data[caption_indice] if caption_indice is not None else None
                         if self.config["storage"]["captions_are_subtitles"]:
-                            text_caption = meta.get("clip_subtitles")[0]["lines"][0]
+                            text_caption = meta.get("clip_subtitles")[0]["lines"]
 
                         sample_writer.write(
                             subsampled_streams,


### PR DESCRIPTION
### Feature
Aim is to capture all requested subtitles with the same clip segment, i.e. subtitles share the same clip time segment.
- could do this in either a clip-first or lang-first manner

### Notes:
Additionally, noticed that `yt-dlp` doesn't like playlist links and causes issues since "requested_subtitles" and other keys are not present; however the metadata returned in `info_dict` can be used to parse all subtitles from full list of videos in playlist. Maybe making that note for video set curation could help others if I didn't miss a preexisting warning.