### PR TITLE
Changed requirement from decord to eva-decord

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ Or from source via
 git clone https://github.com/iejMac/video2dataset
 cd video2dataset
 pip install -e .
-
+```
 
 #### Mac Installation
 
 
 On Mac, replace 'decord' with 'eva_decord' in requirements.txt. For details, see https://github.com/dmlc/decord/issues/213.
-```
+
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ Or from source via
 git clone https://github.com/iejMac/video2dataset
 cd video2dataset
 pip install -e .
+
+
+#### Mac Installation
+
+
+On Mac, replace 'decord' with 'eva_decord' in requirements.txt. For details, see https://github.com/dmlc/decord/issues/213.
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ pandas
 tqdm
 timeout-decorator
 scenedetect[opencv]==0.6
-decord
+eva-decord
 torch==2.0.0
 langdetect
 torchdata==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,8 @@ pandas
 tqdm
 timeout-decorator
 scenedetect[opencv]==0.6
-eva-decord
+decord
+#eva-decord  # use eva-decord instead of decord on Mac (https://github.com/dmlc/decord/issues/213)
 torch==2.0.0
 langdetect
 torchdata==0.6.0


### PR DESCRIPTION
This allows video2dataset to be used on Macs.
See https://github.com/dmlc/decord/issues/213.