### PR TITLE
Resolution subsampler passes through metadata

### DIFF
--- a/video2dataset/subsamplers/resolution_subsampler.py
+++ b/video2dataset/subsamplers/resolution_subsampler.py
@@ -46,4 +46,4 @@ class ResolutionSubsampler(Subsampler):
                 with open(f"{tmpdir}/output.mp4", "rb") as f:
                     subsampled_bytes.append(f.read())
         streams["video"] = subsampled_bytes
-        return streams, None, None
+        return streams, metadata, None


### PR DESCRIPTION
Returning None from resolution_subsampler.py causes an error on L208 of subset_worker.py.

This overwriting of metadata occurs on L189 of subset_worker.py.

Passing the metadata through with no changes fixes this.