### PR TITLE
WIP: Bug fix for wrong numbers of frames in extracted clips

### DIFF
--- a/video2dataset/subsamplers/clipping_subsampler.py
+++ b/video2dataset/subsamplers/clipping_subsampler.py
@@ -85,7 +85,7 @@ def _adjust_clip_spans(
 
 def _collate_clip_spans(clip_spans: List[ClipSpan]) -> Tuple[str, List[int]]:
     """Collates clip spans into a single string for ffmpeg and a list of clip idxs"""
-    clip_times = []
+    clip_times = [0.0]
     clip_idxs = []
     e_prev = 0.0
     clip_idx = 0


### PR DESCRIPTION
I had previously noticed that some extracted clips seemed to have the wrong number of frames. For my dataset, I expect exactly 17 frames per clip, but I was seeing numbers ranging from 8-36 on a sample dataset. This appeared to have been noticed and commented on in the codebase as well (though I can't find where I saw that comment).

It turns out the bug fix is simple. There was a mistake in collating segment times, as can be seen in these before and after screenshots.

![image](https://github.com/iejMac/video2dataset/assets/19638319/68ce8970-fdc7-49b6-b623-cd8603d524f5)
![image](https://github.com/iejMac/video2dataset/assets/19638319/14cbd818-97db-4300-a7ff-21c20ce87af0)
